### PR TITLE
Исправление getProductCategoriesString

### DIFF
--- a/upload/admin/model/extension/exchange1c.php
+++ b/upload/admin/model/extension/exchange1c.php
@@ -851,7 +851,7 @@ class ModelExtensionExchange1c extends Model {
 		foreach ($query->rows as $category) {
 			$categories[] = $category['name'];
 		}
-		$cat_string = implode(',', $categories);
+		$cat_string = implode(', ', $categories);
 		return $cat_string;
 
       } // getProductCategoriesString()


### PR DESCRIPTION
При использовании паттерна {cats} в шаблонах "keyword" и "теги" в настройках SEO товаров наименования категорий "склеиваются".
Это происходит потому, что getProductCategoriesString($product_id) возвращает строку из категорий, разделенных запятыми, а затем в функции getKeywordString эти запятые удаляются.